### PR TITLE
Fix code scanning alert no. 15: Database query built from user-controlled sources

### DIFF
--- a/public/controllers/auth.controller.js
+++ b/public/controllers/auth.controller.js
@@ -5,7 +5,7 @@ const generateJWT = require("../helpers/generateJWT")
 const userAuthentication = async (req, res) => {
     try {
         const { nombre, clave } = req.body // Destructure the request body to retrieve the user's name and password
-        const user = await User.findOne({ nombre }) 
+        const user = await User.findOne({ nombre: { $eq: nombre } }) 
 
         if (!user) return res.status(404).json({
             success: false,


### PR DESCRIPTION
Fixes [https://github.com/VanegasYW/APIRest-JWT/security/code-scanning/15](https://github.com/VanegasYW/APIRest-JWT/security/code-scanning/15)

To fix the problem, we need to ensure that the user input is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This approach ensures that the `nombre` field is treated as a literal value, preventing any potential NoSQL injection attacks.

- Modify the query on line 8 to use the `$eq` operator.
- No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
